### PR TITLE
Allowed specifying of jmx.endpoint via System Property

### DIFF
--- a/src/main/resources/spring-camelwatch-context.xml
+++ b/src/main/resources/spring-camelwatch-context.xml
@@ -14,7 +14,8 @@
 	<context:component-scan base-package="com.sksamuel.camelwatch" />
 
 	<bean id="placeholderConfig"
-		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+			class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE"/>
 		<property name="locations">
 			<list>
 				<value>classpath:camelwatch.properties</value>


### PR DESCRIPTION
This allows running of the WAR unexploded, e.g.

```
java -Xms256m -Xmx512m -Djmx.endpoint=26836 -jar ~/dev/jetty-runner/jetty-runner-8.1.9.v20130131.jar --port 8085 camelwatch.war
```
